### PR TITLE
fixed rust-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,11 @@ emcc dragon-curve.c -Os -o dragon-curve-em.js \
 
 ### Rust example
 
-Create project
+Install wasm-pack https://rustwasm.github.io/wasm-pack/installer
 
-```sh
-docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e "USER=$(whoami)" zloymult/wasm-ttde wasm-pack new rust-example
-```
-
-Compile project
-
-```sh
-docker run --rm -v $(pwd):$(pwd) -w $(pwd)/rust-example -e "USER=$(whoami)" zloymult/wasm-ttde wasm-pack build --release --target web
+```sh 
+cd rust-example
+wasm-pack build --release --target web
 ```
 
 ## Running

--- a/dragon-curve-emscripten/dragon-curve.c
+++ b/dragon-curve-emscripten/dragon-curve.c
@@ -29,3 +29,29 @@ void dragonCurve(double source[], int size, int len, double x0, double y0)
   }
 }
 #endif
+
+/**
+  The “pure LLVM” approach (in dragon-curve-llvm) is minimalistic on purpose; we compiled our program without system libraries. 
+  We also manage memory in the most atrocious of possible ways: by calculating an offset to the heap. 
+  That allowed us to demystify WebAssembly’s memory model. 
+  In real-world applications, we want to allocate memory properly and use system libraries, where “system” is our browser: 
+  WebAssembly still runs in the sandbox and has no direct access to your operating system.
+
+  All of that can be done with the help of the emscripten: 
+  a toolchain for compiling WebAssembly that takes care of simulating many system’s capabilities inside the browser: 
+  working with STDIN, STDOUT, and filesystem, and even OpenGL graphics that gets automatically translated into WebGL. 
+  It also integrates Bynarien that we used to slim down our binary, so we don’t have to worry about additional optimizations anymore.
+
+  We went to the trouble of packaging ecmsripten into the Docker image for you, so you don’t have to install anything on your system to run the command below:
+  docker run --rm -v $(pwd):$(pwd) -w $(pwd) zloymult/wasm-build-kit \
+  emcc dragon-curve.c -Os -o dragon-curve.js \
+  -s EXPORTED_FUNCTIONS='["_dragonCurve", "_malloc", "_free"]' \
+  -s EXPORTED_RUNTIME_METHODS='["ccall"]' \
+  -s MODULARIZE=1
+
+  -Os tells emscripten to optimize for size: both for Wasm and JS
+  Note that we only need to specify the .js file name as the output, .wasm is generated automatically.
+  We can also choose which function we want to export from the resulting Wasm module, note that it requires an underscore before the name, hence -s EXPORTED_FUNCTIONS='["_dragonCurve", "_malloc", "_free"]'. The last two functions will help us work with memory.
+  As our source code is C, we also have to export the ccall function that emscripten generates for us.
+  MODULARIZE=1 allows us to use a global Module function that returns a Promise with an instance of our wasm module.
+*/

--- a/dragon-curve-pure-llvm/dragon-curve.c
+++ b/dragon-curve-pure-llvm/dragon-curve.c
@@ -31,3 +31,28 @@ void dragonCurve(double source[], int size, int len, double x0, double y0)
   }
 }
 #endif
+
+/**
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) zloymult/wasm-build-kit \
+clang --target=wasm32 -O3 -nostdlib -Wl,--no-entry -Wl,--export-all -o dragon-curve.wasm dragon-curve.c
+
+
+--target=wasm32 tells a compiler to use WebAssembly as a target for compilation.
+-O3 applies a maximum amount of optimizations.
+-nostdlib tells not to use system libraries, as they are useless in the context of a browser.
+-Wl,--no-entry -Wl,--export-all are flags that tell the linker to export all the C functions we defined from the WebAssembly module and ignore the absence of main().
+
+
+to inspect generated wasm file,
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) zloymult/wasm-build-kit \
+wasm-objdump dragon-curve.wasm -s
+
+
+We can reduce the size of our binary with an awesome tool called Bynarien that is a part of the WebAssembly toolchain.
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) zloymult/wasm-build-kit \
+wasm-opt -Os dragon-curve.wasm -o dragon-curve-opt.wasm
+
+to read wasm in text,
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) zloymult/wasm-build-kit \
+wasm2wat dragon-curve-opt.wasm > dragon-curve-opt.wat
+*/

--- a/dragon-curve-pure-llvm/index.html
+++ b/dragon-curve-pure-llvm/index.html
@@ -1,3 +1,20 @@
+<!-- We use the standard fetch API to load our module, 
+    and the built-in WebAssembly JavaScript API to instantiate it.
+    WebAssembly.instantiateStreaming returns a promise that resolves with a module object, containing an instance of our module. 
+    Our C functions are now available as the instance’s exports, and we can use them from JavaScript however we please. 
+
+     a memory object representing the linear memory of our WebAssembly module can contain important things like our stack of instructions for the virtual machine.
+     __heap_base property gives us an offset into a memory region that is safe for us to use (the heap).
+     We give the offset into the “good” memory to our dragonCurve function, call it, and extract the contents of the heap populated with coordinates as a Float64Array.
+     The rest is just drawing a line on the canvas based on the coordinates extracted from our Wasm module. 
+
+     Run this to see it:
+     docker run --rm -v $(pwd):$(pwd) -w $(pwd) -p 8000:8000 zloymult/wasm-build-kit \
+     python -m http.server
+
+     Navigate to http://localhost:8000 and behold the dragon curve!
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/rust-example/index.html
+++ b/rust-example/index.html
@@ -8,7 +8,7 @@
   <body>
     <canvas id="canvas" width="1920" height="1080"></canvas>
     <script type="module">
-      import init, { dragon_curve } from "/rust-example/pkg/rust_example.js";
+      import init, { dragon_curve } from "../pkg/rust_example.js";
       (async function run() {
         await init();
         const size = 2000;


### PR DESCRIPTION
The rust example does not work anymore per instructions from the original tutorial (see GitHub issue #3 )

I've added / fixed...
1. Instructions on how to wasm-pack build locally for rust-example
2. Path for dragon curve function
3. Parts of the tutorial are embedded as comments for reference.

